### PR TITLE
feat: auto setup, uninstall, version command

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,28 +50,39 @@ Claude Code 在运行过程中会读取并上报设备标识符（硬件 UUID、
 
 ### 安装
 
-**npm 安装（推荐）：**
+> ⚠️ **请只选择其中一种方式，切勿同时安装！**
+
+**方式 A：npm（推荐）**
 
 ```bash
 npm install -g claude-cac
-cac setup
+cac setup          # 自动配置 PATH，无需手动修改
 ```
 
-**一键脚本安装：**
+**方式 B：一键脚本**
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/nmhjklnm/cac/master/install.sh | bash
 ```
 
-**手动安装：**
+安装完成后重开终端，或执行 `source ~/.zshrc`。
+
+### 卸载
 
 ```bash
-git clone https://github.com/nmhjklnm/cac.git
-cd cac
-bash install.sh
+cac delete                       # 自动清除数据 + PATH 配置
+npm uninstall -g claude-cac      # npm 用户需额外执行此步
 ```
 
-安装完成后重开终端，或执行 `source ~/.zshrc`。
+<details>
+<summary>手动卸载</summary>
+
+```bash
+rm -rf ~/.cac                    # 删除数据目录
+rm -f ~/bin/cac                  # 删除命令（bash 安装）
+# 编辑 ~/.zshrc，移除 # >>> cac ... <<< 标记块
+```
+</details>
 
 ### 使用
 
@@ -96,12 +107,14 @@ claude
 
 | 命令 | 说明 |
 |:---|:---|
+| `cac setup` | 首次安装，自动配置 PATH |
 | `cac add <名字> <host:port:u:p>` | 添加配置 |
-| `cac <名字>` | 切换配置，刷新所有隐私参数 |
+| `cac <名字>` | 切换配置 |
 | `cac ls` | 列出所有配置 |
 | `cac check` | 检查代理 + 安全防护 + 冲突检测 |
-| `cac stop` | 临时停用保护 |
-| `cac -c` | 恢复保护 |
+| `cac stop` / `cac -c` | 停用 / 恢复保护 |
+| `cac delete` | 卸载（清除数据 + PATH） |
+| `cac -v` | 版本号 + 安装方式 |
 
 ### 工作原理
 
@@ -187,28 +200,39 @@ All `claude` invocations (including Agent subprocesses) are intercepted. Zero in
 
 ### Installation
 
-**npm install (recommended):**
+> ⚠️ **Choose only ONE method. Do NOT install both!**
+
+**Option A: npm (recommended)**
 
 ```bash
 npm install -g claude-cac
-cac setup
+cac setup          # auto-configures PATH
 ```
 
-**One-line script install:**
+**Option B: One-line script**
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/nmhjklnm/cac/master/install.sh | bash
 ```
 
-**Manual install:**
+Restart your terminal or run `source ~/.zshrc` after installation.
+
+### Uninstallation
 
 ```bash
-git clone https://github.com/nmhjklnm/cac.git
-cd cac
-bash install.sh
+cac delete                       # removes all data + PATH entries
+npm uninstall -g claude-cac      # npm users: also run this
 ```
 
-After installation, restart your terminal or run `source ~/.zshrc`.
+<details>
+<summary>Manual uninstall</summary>
+
+```bash
+rm -rf ~/.cac                    # remove data directory
+rm -f ~/bin/cac                  # remove command (bash install)
+# edit ~/.zshrc, remove the # >>> cac ... <<< block
+```
+</details>
 
 ### Usage
 
@@ -225,12 +249,14 @@ On first use, run `/login` inside Claude Code to authenticate.
 
 | Command | Description |
 |:---|:---|
+| `cac setup` | First-time setup, auto-configures PATH |
 | `cac add <name> <host:port:u:p>` | Add profile |
-| `cac <name>` | Switch profile, refresh all privacy parameters |
+| `cac <name>` | Switch profile |
 | `cac ls` | List all profiles |
 | `cac check` | Check proxy + security + conflict detection |
-| `cac stop` | Temporarily disable protection |
-| `cac -c` | Re-enable protection |
+| `cac stop` / `cac -c` | Disable / re-enable protection |
+| `cac delete` | Uninstall (removes data + PATH) |
+| `cac -v` | Version + installation method |
 
 ### How It Works
 

--- a/build.sh
+++ b/build.sh
@@ -16,6 +16,8 @@ SOURCES=(
     cmd_env.sh
     cmd_check.sh
     cmd_stop.sh
+    cmd_delete.sh
+    cmd_version.sh
     cmd_help.sh
     main.sh
 )

--- a/cac
+++ b/cac
@@ -9,6 +9,8 @@ ENVS_DIR="$CAC_DIR/envs"
 # ━━━ utils.sh ━━━
 # ── utils: 颜色、读写、UUID、proxy 解析 ───────────────────────
 
+CAC_VERSION="1.0.0"
+
 _read()   { [[ -f "$1" ]] && tr -d '[:space:]' < "$1" || echo "${2:-}"; }
 _bold()   { printf '\033[1m%s\033[0m' "$*"; }
 _green()  { printf '\033[32m%s\033[0m' "$*"; }
@@ -84,6 +86,90 @@ _require_env() {
 _find_real_claude() {
     PATH=$(echo "$PATH" | tr ':' '\n' | grep -v "$CAC_DIR/bin" | tr '\n' ':') \
         command -v claude 2>/dev/null || true
+}
+
+_detect_rc_file() {
+    if [[ -f "$HOME/.zshrc" ]]; then
+        echo "$HOME/.zshrc"
+    elif [[ -f "$HOME/.bashrc" ]]; then
+        echo "$HOME/.bashrc"
+    elif [[ -f "$HOME/.bash_profile" ]]; then
+        echo "$HOME/.bash_profile"
+    else
+        echo ""
+    fi
+}
+
+_install_method() {
+    local self="$0"
+    local resolved="$self"
+    if [[ -L "$self" ]]; then
+        resolved=$(readlink "$self" 2>/dev/null || echo "$self")
+        # 处理相对路径的符号链接
+        if [[ "$resolved" != /* ]]; then
+            resolved="$(dirname "$self")/$resolved"
+        fi
+    fi
+    if [[ "$resolved" == *"node_modules"* ]] || [[ -f "$(dirname "$resolved")/package.json" ]]; then
+        echo "npm"
+    else
+        echo "bash"
+    fi
+}
+
+_write_path_to_rc() {
+    local rc_file="${1:-$(_detect_rc_file)}"
+    if [[ -z "$rc_file" ]]; then
+        echo "  $(_yellow '⚠') 未找到 shell 配置文件，请手动添加 PATH："
+        echo '    export PATH="$HOME/bin:$PATH"'
+        echo '    export PATH="$HOME/.cac/bin:$PATH"'
+        return 0
+    fi
+
+    if grep -q '# >>> cac >>>' "$rc_file" 2>/dev/null; then
+        echo "  ✓ PATH 已存在于 $rc_file，跳过"
+        return 0
+    fi
+
+    # 兼容旧格式：如果存在旧的 cac PATH 行，先移除
+    if grep -q '\.cac/bin' "$rc_file" 2>/dev/null; then
+        _remove_path_from_rc "$rc_file"
+    fi
+
+    cat >> "$rc_file" << 'EOF'
+
+# >>> cac — Claude Code Cloak >>>
+export PATH="$HOME/bin:$PATH"          # cac 命令
+export PATH="$HOME/.cac/bin:$PATH"     # claude wrapper
+# <<< cac — Claude Code Cloak <<<
+EOF
+    echo "  ✓ PATH 已写入 $rc_file"
+    return 0
+}
+
+_remove_path_from_rc() {
+    local rc_file="${1:-$(_detect_rc_file)}"
+    [[ -z "$rc_file" ]] && return 0
+
+    # 移除标记块格式（新格式）
+    if grep -q '# >>> cac' "$rc_file" 2>/dev/null; then
+        local tmp="${rc_file}.cac-tmp"
+        awk '/# >>> cac/{skip=1; next} /# <<< cac/{skip=0; next} !skip' "$rc_file" > "$tmp"
+        cat -s "$tmp" > "$rc_file"
+        rm -f "$tmp"
+        echo "  ✓ 已从 $rc_file 移除 PATH 配置"
+        return 0
+    fi
+
+    # 兼容旧格式
+    if grep -qE '(\.cac/bin|# cac —)' "$rc_file" 2>/dev/null; then
+        local tmp="${rc_file}.cac-tmp"
+        grep -vE '(# cac — Claude Code Cloak|\.cac/bin|# cac 命令|# claude wrapper)' "$rc_file" > "$tmp" || true
+        cat -s "$tmp" > "$rc_file"
+        rm -f "$tmp"
+        echo "  ✓ 已从 $rc_file 移除 PATH 配置（旧格式）"
+        return 0
+    fi
 }
 
 _update_statsig() {
@@ -782,16 +868,19 @@ cmd_setup() {
     _generate_ca_cert
     echo "  ✓ mTLS CA → $CAC_DIR/ca/ca_cert.pem"
 
+    # 自动写入 PATH 到 shell rc 文件
+    local rc_file
+    rc_file=$(_detect_rc_file)
+    _write_path_to_rc "$rc_file"
+
     echo
     echo "── 下一步 ──────────────────────────────────────────────"
-    echo "1. 将以下两行加到 ~/.zshrc 最前面："
+    if [[ -n "$rc_file" ]]; then
+        echo "1. 执行以下命令使配置生效（或重开终端）："
+        echo "   source $rc_file"
+    fi
     echo
-    echo "   export PATH=\"\$HOME/bin:\$PATH\"          # cac 命令"
-    echo "   export PATH=\"$CAC_DIR/bin:\$PATH\"  # claude wrapper"
-    echo
-    echo "2. source ~/.zshrc"
-    echo
-    echo "3. 添加第一个代理环境："
+    echo "2. 添加第一个代理环境："
     echo "   cac add <名字> <host:port:user:pass>"
 }
 
@@ -1132,6 +1221,67 @@ cmd_continue() {
     echo "$(_green "✓") cac 已恢复 — 当前环境：$(_bold "$current")"
 }
 
+# ━━━ cmd_delete.sh ━━━
+# ── cmd: delete（卸载）────────────────────────────────────────
+
+cmd_delete() {
+    echo "=== cac delete ==="
+    echo
+
+    local rc_file
+    rc_file=$(_detect_rc_file)
+
+    _remove_path_from_rc "$rc_file"
+
+    if [[ -d "$CAC_DIR" ]]; then
+        rm -rf "$CAC_DIR"
+        echo "  ✓ 已删除 $CAC_DIR"
+    else
+        echo "  - $CAC_DIR 不存在，跳过"
+    fi
+
+    local method
+    method=$(_install_method)
+    echo
+    if [[ "$method" == "npm" ]]; then
+        echo "  ✓ 已清除所有 cac 数据和配置"
+        echo
+        echo "要完全卸载 cac 命令，请执行："
+        echo "  npm uninstall -g claude-cac"
+    else
+        if [[ -f "$HOME/bin/cac" ]]; then
+            rm -f "$HOME/bin/cac"
+            echo "  ✓ 已删除 $HOME/bin/cac"
+        fi
+        echo "  ✓ 卸载完成"
+    fi
+
+    echo
+    if [[ -n "$rc_file" ]]; then
+        echo "请重开终端或执行 source $rc_file 使变更生效。"
+    else
+        echo "请重开终端使变更生效。"
+    fi
+}
+
+# ━━━ cmd_version.sh ━━━
+# ── cmd: version ───────────────────────────────────────────────
+
+cmd_version() {
+    local method
+    method=$(_install_method)
+
+    local method_label
+    case "$method" in
+        npm)  method_label="npm (Node)" ;;
+        bash) method_label="bash (Shell Script)" ;;
+        *)    method_label="unknown" ;;
+    esac
+
+    echo "cac $CAC_VERSION"
+    echo "安装方式: $method_label"
+}
+
 # ━━━ cmd_help.sh ━━━
 # ── cmd: help ──────────────────────────────────────────────────
 
@@ -1140,13 +1290,15 @@ cat <<EOF
 $(_bold "cac") — Claude Anti-fingerprint Cloak
 
 $(_bold "用法：")
-  cac setup                         首次安装
+  cac setup                         首次安装（自动配置 PATH）
   cac add <名字> <host:port:u:p>    添加新环境（需要 yes 确认）
   cac <名字>                        切换到指定环境
   cac ls                            列出所有环境
   cac check                         核查当前环境（代理 + 安全防护）
   cac stop                          临时停用，claude 裸跑
   cac -c                            恢复停用
+  cac delete                        卸载 cac（清除所有数据和配置）
+  cac -v                            查看版本号和安装方式
 
 $(_bold "代理格式：")
   host:port:user:pass    带认证的 SOCKS5
@@ -1181,13 +1333,15 @@ EOF
 [[ $# -eq 0 ]] && { cmd_help; exit 0; }
 
 case "$1" in
-    setup)          cmd_setup         ;;
-    add)            cmd_add  "${@:2}" ;;
-    ls|list)        cmd_ls            ;;
-    check)          cmd_check         ;;
-    stop)           cmd_stop          ;;
-    -c)             cmd_continue      ;;
-    help|--help|-h) cmd_help          ;;
-    *)              cmd_switch "$1"   ;;
+    setup)              cmd_setup         ;;
+    add)                cmd_add  "${@:2}" ;;
+    ls|list)            cmd_ls            ;;
+    check)              cmd_check         ;;
+    stop)               cmd_stop          ;;
+    -c)                 cmd_continue      ;;
+    delete|uninstall)   cmd_delete        ;;
+    -v|--version)       cmd_version       ;;
+    help|--help|-h)     cmd_help          ;;
+    *)                  cmd_switch "$1"   ;;
 esac
 

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,6 @@ set -euo pipefail
 
 REPO="https://raw.githubusercontent.com/nmhjklnm/cac/master"
 BIN_DIR="$HOME/bin"
-CAC_BIN="$HOME/.cac/bin"
 
 # 颜色
 green() { printf '\033[32m%s\033[0m\n' "$*"; }
@@ -14,14 +13,33 @@ red() { printf '\033[31m%s\033[0m\n' "$*"; }
 echo "=== cac — Claude Code Cloak 安装 ==="
 echo
 
-# 1. 下载 cac 到 ~/bin
+# 1. 检查是否已通过 npm 安装
+if command -v cac &>/dev/null; then
+    local_cac=$(command -v cac)
+    if [[ "$local_cac" == *"node_modules"* ]] || [[ -f "$(dirname "$local_cac" 2>/dev/null)/package.json" ]]; then
+        red "⚠ 检测到已通过 npm 安装 claude-cac，请勿同时使用两种安装方式！"
+        echo "  如需切换到 bash 安装，请先执行："
+        echo "    npm uninstall -g claude-cac"
+        exit 1
+    fi
+fi
+
+# 2. 下载 cac 到 ~/bin
 mkdir -p "$BIN_DIR"
 printf "下载 cac ... "
 curl -fsSL "$REPO/cac" -o "$BIN_DIR/cac"
 chmod +x "$BIN_DIR/cac"
 green "✓"
 
-# 2. 写入 PATH（检测用哪个 rc 文件）
+# 3. 初始化（cac setup 会自动写入 PATH 到 shell rc 文件）
+export PATH="$BIN_DIR:$PATH"
+"$BIN_DIR/cac" setup
+
+echo
+green "✓ 安装完成"
+echo
+
+# 4. 提示生效方式
 RC_FILE=""
 if [[ -f "$HOME/.zshrc" ]]; then
     RC_FILE="$HOME/.zshrc"
@@ -32,35 +50,9 @@ elif [[ -f "$HOME/.bash_profile" ]]; then
 fi
 
 if [[ -n "$RC_FILE" ]]; then
-    if ! grep -q 'cac/bin' "$RC_FILE" 2>/dev/null; then
-        printf "写入 PATH 到 %s ... " "$RC_FILE"
-        cat >> "$RC_FILE" << 'EOF'
-
-# cac — Claude Code Cloak
-export PATH="$HOME/bin:$PATH"          # cac 命令
-export PATH="$HOME/.cac/bin:$PATH"     # claude wrapper（必须最前）
-EOF
-        green "✓"
-    else
-        yellow "PATH 已存在，跳过"
-    fi
-else
-    yellow "⚠ 未找到 shell 配置文件，请手动添加："
-    echo '  export PATH="$HOME/bin:$PATH"'
-    echo '  export PATH="$HOME/.cac/bin:$PATH"'
+    echo "执行以下命令使配置生效（或重开终端）："
+    echo "  source $RC_FILE"
+    echo
 fi
-
-# 3. 初始化 wrapper 和 ioreg shim
-printf "初始化 ... "
-export PATH="$BIN_DIR:$PATH"
-"$BIN_DIR/cac" setup 2>&1 | grep -E "✓|错误" || true
-green "✓"
-
-echo
-green "✓ 安装完成"
-echo
-echo "执行以下命令使配置生效："
-echo "  source $RC_FILE"
-echo
 echo "然后添加第一个代理配置："
 echo "  cac add <名字> <host:port:user:pass>"

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -16,10 +16,14 @@ console.log(`
   ✅ claude-cac 安装成功
 
   首次使用：
-    cac setup                          初始化
+    cac setup                          初始化（自动配置 PATH）
     cac add <名字> <host:port:u:p>     添加代理配置
     cac <名字>                         切换配置
     claude                             启动 Claude Code
+
+  其他命令：
+    cac -v                             查看版本和安装方式
+    cac delete                         卸载 cac
 
   更多信息：https://github.com/nmhjklnm/cac
 `);

--- a/src/cmd_delete.sh
+++ b/src/cmd_delete.sh
@@ -1,0 +1,41 @@
+# ── cmd: delete（卸载）────────────────────────────────────────
+
+cmd_delete() {
+    echo "=== cac delete ==="
+    echo
+
+    local rc_file
+    rc_file=$(_detect_rc_file)
+
+    _remove_path_from_rc "$rc_file"
+
+    if [[ -d "$CAC_DIR" ]]; then
+        rm -rf "$CAC_DIR"
+        echo "  ✓ 已删除 $CAC_DIR"
+    else
+        echo "  - $CAC_DIR 不存在，跳过"
+    fi
+
+    local method
+    method=$(_install_method)
+    echo
+    if [[ "$method" == "npm" ]]; then
+        echo "  ✓ 已清除所有 cac 数据和配置"
+        echo
+        echo "要完全卸载 cac 命令，请执行："
+        echo "  npm uninstall -g claude-cac"
+    else
+        if [[ -f "$HOME/bin/cac" ]]; then
+            rm -f "$HOME/bin/cac"
+            echo "  ✓ 已删除 $HOME/bin/cac"
+        fi
+        echo "  ✓ 卸载完成"
+    fi
+
+    echo
+    if [[ -n "$rc_file" ]]; then
+        echo "请重开终端或执行 source $rc_file 使变更生效。"
+    else
+        echo "请重开终端使变更生效。"
+    fi
+}

--- a/src/cmd_help.sh
+++ b/src/cmd_help.sh
@@ -5,13 +5,15 @@ cat <<EOF
 $(_bold "cac") — Claude Anti-fingerprint Cloak
 
 $(_bold "用法：")
-  cac setup                         首次安装
+  cac setup                         首次安装（自动配置 PATH）
   cac add <名字> <host:port:u:p>    添加新环境（需要 yes 确认）
   cac <名字>                        切换到指定环境
   cac ls                            列出所有环境
   cac check                         核查当前环境（代理 + 安全防护）
   cac stop                          临时停用，claude 裸跑
   cac -c                            恢复停用
+  cac delete                        卸载 cac（清除所有数据和配置）
+  cac -v                            查看版本号和安装方式
 
 $(_bold "代理格式：")
   host:port:user:pass    带认证的 SOCKS5

--- a/src/cmd_setup.sh
+++ b/src/cmd_setup.sh
@@ -42,15 +42,18 @@ cmd_setup() {
     _generate_ca_cert
     echo "  ✓ mTLS CA → $CAC_DIR/ca/ca_cert.pem"
 
+    # 自动写入 PATH 到 shell rc 文件
+    local rc_file
+    rc_file=$(_detect_rc_file)
+    _write_path_to_rc "$rc_file"
+
     echo
     echo "── 下一步 ──────────────────────────────────────────────"
-    echo "1. 将以下两行加到 ~/.zshrc 最前面："
+    if [[ -n "$rc_file" ]]; then
+        echo "1. 执行以下命令使配置生效（或重开终端）："
+        echo "   source $rc_file"
+    fi
     echo
-    echo "   export PATH=\"\$HOME/bin:\$PATH\"          # cac 命令"
-    echo "   export PATH=\"$CAC_DIR/bin:\$PATH\"  # claude wrapper"
-    echo
-    echo "2. source ~/.zshrc"
-    echo
-    echo "3. 添加第一个代理环境："
+    echo "2. 添加第一个代理环境："
     echo "   cac add <名字> <host:port:user:pass>"
 }

--- a/src/cmd_version.sh
+++ b/src/cmd_version.sh
@@ -1,0 +1,16 @@
+# ── cmd: version ───────────────────────────────────────────────
+
+cmd_version() {
+    local method
+    method=$(_install_method)
+
+    local method_label
+    case "$method" in
+        npm)  method_label="npm (Node)" ;;
+        bash) method_label="bash (Shell Script)" ;;
+        *)    method_label="unknown" ;;
+    esac
+
+    echo "cac $CAC_VERSION"
+    echo "安装方式: $method_label"
+}

--- a/src/main.sh
+++ b/src/main.sh
@@ -3,12 +3,14 @@
 [[ $# -eq 0 ]] && { cmd_help; exit 0; }
 
 case "$1" in
-    setup)          cmd_setup         ;;
-    add)            cmd_add  "${@:2}" ;;
-    ls|list)        cmd_ls            ;;
-    check)          cmd_check         ;;
-    stop)           cmd_stop          ;;
-    -c)             cmd_continue      ;;
-    help|--help|-h) cmd_help          ;;
-    *)              cmd_switch "$1"   ;;
+    setup)              cmd_setup         ;;
+    add)                cmd_add  "${@:2}" ;;
+    ls|list)            cmd_ls            ;;
+    check)              cmd_check         ;;
+    stop)               cmd_stop          ;;
+    -c)                 cmd_continue      ;;
+    delete|uninstall)   cmd_delete        ;;
+    -v|--version)       cmd_version       ;;
+    help|--help|-h)     cmd_help          ;;
+    *)                  cmd_switch "$1"   ;;
 esac

--- a/src/utils.sh
+++ b/src/utils.sh
@@ -1,5 +1,7 @@
 # ── utils: 颜色、读写、UUID、proxy 解析 ───────────────────────
 
+CAC_VERSION="1.0.0"
+
 _read()   { [[ -f "$1" ]] && tr -d '[:space:]' < "$1" || echo "${2:-}"; }
 _bold()   { printf '\033[1m%s\033[0m' "$*"; }
 _green()  { printf '\033[32m%s\033[0m' "$*"; }
@@ -75,6 +77,90 @@ _require_env() {
 _find_real_claude() {
     PATH=$(echo "$PATH" | tr ':' '\n' | grep -v "$CAC_DIR/bin" | tr '\n' ':') \
         command -v claude 2>/dev/null || true
+}
+
+_detect_rc_file() {
+    if [[ -f "$HOME/.zshrc" ]]; then
+        echo "$HOME/.zshrc"
+    elif [[ -f "$HOME/.bashrc" ]]; then
+        echo "$HOME/.bashrc"
+    elif [[ -f "$HOME/.bash_profile" ]]; then
+        echo "$HOME/.bash_profile"
+    else
+        echo ""
+    fi
+}
+
+_install_method() {
+    local self="$0"
+    local resolved="$self"
+    if [[ -L "$self" ]]; then
+        resolved=$(readlink "$self" 2>/dev/null || echo "$self")
+        # 处理相对路径的符号链接
+        if [[ "$resolved" != /* ]]; then
+            resolved="$(dirname "$self")/$resolved"
+        fi
+    fi
+    if [[ "$resolved" == *"node_modules"* ]] || [[ -f "$(dirname "$resolved")/package.json" ]]; then
+        echo "npm"
+    else
+        echo "bash"
+    fi
+}
+
+_write_path_to_rc() {
+    local rc_file="${1:-$(_detect_rc_file)}"
+    if [[ -z "$rc_file" ]]; then
+        echo "  $(_yellow '⚠') 未找到 shell 配置文件，请手动添加 PATH："
+        echo '    export PATH="$HOME/bin:$PATH"'
+        echo '    export PATH="$HOME/.cac/bin:$PATH"'
+        return 0
+    fi
+
+    if grep -q '# >>> cac >>>' "$rc_file" 2>/dev/null; then
+        echo "  ✓ PATH 已存在于 $rc_file，跳过"
+        return 0
+    fi
+
+    # 兼容旧格式：如果存在旧的 cac PATH 行，先移除
+    if grep -q '\.cac/bin' "$rc_file" 2>/dev/null; then
+        _remove_path_from_rc "$rc_file"
+    fi
+
+    cat >> "$rc_file" << 'EOF'
+
+# >>> cac — Claude Code Cloak >>>
+export PATH="$HOME/bin:$PATH"          # cac 命令
+export PATH="$HOME/.cac/bin:$PATH"     # claude wrapper
+# <<< cac — Claude Code Cloak <<<
+EOF
+    echo "  ✓ PATH 已写入 $rc_file"
+    return 0
+}
+
+_remove_path_from_rc() {
+    local rc_file="${1:-$(_detect_rc_file)}"
+    [[ -z "$rc_file" ]] && return 0
+
+    # 移除标记块格式（新格式）
+    if grep -q '# >>> cac' "$rc_file" 2>/dev/null; then
+        local tmp="${rc_file}.cac-tmp"
+        awk '/# >>> cac/{skip=1; next} /# <<< cac/{skip=0; next} !skip' "$rc_file" > "$tmp"
+        cat -s "$tmp" > "$rc_file"
+        rm -f "$tmp"
+        echo "  ✓ 已从 $rc_file 移除 PATH 配置"
+        return 0
+    fi
+
+    # 兼容旧格式
+    if grep -qE '(\.cac/bin|# cac —)' "$rc_file" 2>/dev/null; then
+        local tmp="${rc_file}.cac-tmp"
+        grep -vE '(# cac — Claude Code Cloak|\.cac/bin|# cac 命令|# claude wrapper)' "$rc_file" > "$tmp" || true
+        cat -s "$tmp" > "$rc_file"
+        rm -f "$tmp"
+        echo "  ✓ 已从 $rc_file 移除 PATH 配置（旧格式）"
+        return 0
+    fi
 }
 
 _update_statsig() {


### PR DESCRIPTION
## Summary

- **`cac setup` 自动配置 PATH** — 不再要求用户手动编辑 `~/.zshrc`，setup 自动写入并使用 `# >>> cac ... <<<` 标记块便于清理
- **`cac delete` 卸载命令** — 清除 `~/.cac` 目录、移除 shell rc 中 PATH 配置；npm 安装提示 `npm uninstall`，bash 安装直接删除 `~/bin/cac`
- **`cac -v` 版本命令** — 显示版本号 + 安装方式（npm / bash）
- **`install.sh` 冲突检测** — 检测到已通过 npm 安装时拒绝重复安装
- **README 精简重构** — 警告勿同时安装两种方式、新增卸载文档、整体精简 56 行

## Test plan

- [x] `npm install -g claude-cac && cac setup` 验证自动写入 PATH
- [x] `cac -v` 验证版本号和安装方式显示
- [x] `cac delete` 验证数据清理和 rc 文件 PATH 移除
- [x] `cac delete` 重复执行不报错（幂等性）
- [x] bash 安装方式下 `install.sh` 检测 npm 冲突