### PR TITLE
fix: use Buffer accumulation in relay.js to prevent binary data corruption

### DIFF
--- a/src/relay.js
+++ b/src/relay.js
@@ -133,15 +133,15 @@ function httpConnect(targetHost, targetPort, cb) {
     connectReq += '\r\n';
     sock.write(connectReq);
 
-    let buf = '';
+    let buf = Buffer.alloc(0);
     sock.on('data', function onData(chunk) {
-      buf += chunk.toString();
+      buf = Buffer.concat([buf, chunk]);
       const idx = buf.indexOf('\r\n\r\n');
       if (idx === -1) return;
 
-      const statusLine = buf.substring(0, buf.indexOf('\r\n'));
+      const statusLine = buf.slice(0, buf.indexOf('\r\n')).toString();
       const statusCode = parseInt(statusLine.split(' ')[1], 10);
-      const remaining = Buffer.from(buf.substring(idx + 4));
+      const remaining = buf.slice(idx + 4);
 
       sock.removeListener('data', onData);
 
@@ -207,16 +207,18 @@ const server = net.createServer({ pauseOnConnect: true }, (clientSock) => {
 
 function handleConnect(clientSock, targetHost, targetPort, headerRest) {
   // Consume remaining headers until \r\n\r\n
-  let restBuf = headerRest;
+  // Keep as Buffer to avoid corrupting binary data (e.g. TLS ClientHello)
+  // that may arrive in the same chunk as the last header bytes.
+  let restBuf = Buffer.from(headerRest);
   const consumeHeaders = () => {
     const endIdx = restBuf.indexOf('\r\n\r\n');
     if (endIdx !== -1) {
-      const trailing = restBuf.substring(endIdx + 4);
+      const trailing = restBuf.slice(endIdx + 4);
       doConnect(trailing);
       return;
     }
     clientSock.once('data', (chunk) => {
-      restBuf += chunk.toString();
+      restBuf = Buffer.concat([restBuf, chunk]);
       consumeHeaders();
     });
   };


### PR DESCRIPTION
## Summary

- `httpConnect()` accumulated TCP socket data using `buf += chunk.toString()`, converting binary bytes through UTF-8 encoding — any invalid UTF-8 byte sequences are replaced with U+FFFD, silently corrupting binary payloads (e.g. TLS ClientHello) that may co-arrive with the last header bytes
- `handleConnect()` `consumeHeaders()` had the same string accumulation bug for trailing data after the CONNECT headers

## Changes

Switch both accumulators from string concatenation to `Buffer.concat()`:

- `httpConnect`: `let buf = Buffer.alloc(0)` + `buf = Buffer.concat([buf, chunk])` + `buf.slice()` instead of substring
- `handleConnect`: `let restBuf = Buffer.from(headerRest)` + `restBuf = Buffer.concat([restBuf, chunk])`

## Test plan

- [ ] HTTPS proxy requests tunnel correctly without TLS handshake failures
- [ ] Plain HTTP CONNECT requests continue to work

Closes https://github.com/nmhjklnm/cac/issues/9