### PR TITLE
fix: write upstreamExtra to client instead of unshifting back to client readable

### DIFF
--- a/src/relay.js
+++ b/src/relay.js
@@ -235,8 +235,9 @@ function handleConnect(clientSock, targetHost, targetPort, headerRest) {
       upstreamSock.pipe(clientSock);
 
       // Send any extra data that came in after handshake
+      // upstreamExtra is data from the target server; write it to the client.
       if (upstreamExtra && upstreamExtra.length > 0) {
-        clientSock.unshift(upstreamExtra);
+        clientSock.write(upstreamExtra);
       }
       if (trailingData && trailingData.length > 0) {
         upstreamSock.write(trailingData);


### PR DESCRIPTION
## Summary

- In `doConnect()`, `upstreamExtra` is data received from the target server during the upstream CONNECT handshake
- `clientSock.unshift(upstreamExtra)` pushed this data back into the client socket's **readable** stream, causing the existing `clientSock.pipe(upstreamSock)` to immediately re-forward it to the upstream — exactly the wrong direction
- The data should be sent to the local HTTP client

## Changes

Replace `clientSock.unshift(upstreamExtra)` with `clientSock.write(upstreamExtra)` so server-originating data flows client-ward.

## Test plan

- [ ] Bidirectional CONNECT tunnels transfer data correctly
- [ ] No data loop or 502 errors on connections where upstream sends data immediately after CONNECT 200

Closes https://github.com/nmhjklnm/cac/issues/10