### PR TITLE
fix: add Proxy-Authorization header in handlePlainHttp for authenticated upstream

### DIFF
--- a/src/relay.js
+++ b/src/relay.js
@@ -253,7 +253,12 @@ function handleConnect(clientSock, targetHost, targetPort, headerRest) {
 function handlePlainHttp(clientSock, firstLine, headerRest) {
   // For plain HTTP requests, forward directly to upstream proxy
   const sock = net.connect(upstreamPort, upstreamHost, () => {
-    sock.write(firstLine + '\r\n' + headerRest);
+    let authHeader = '';
+    if (upstreamUser) {
+      const cred = Buffer.from(upstreamUser + ':' + upstreamPass).toString('base64');
+      authHeader = 'Proxy-Authorization: Basic ' + cred + '\r\n';
+    }
+    sock.write(firstLine + '\r\n' + authHeader + headerRest);
     clientSock.pipe(sock);
     sock.pipe(clientSock);
   });


### PR DESCRIPTION
## Summary

- `httpConnect()` correctly adds `Proxy-Authorization: Basic` when forwarding CONNECT requests to an authenticated upstream proxy
- `handlePlainHttp()`, which handles plain HTTP (non-HTTPS) requests, forwarded the original request to the upstream without any authentication header, causing all plain HTTP requests to fail with **407 Proxy Authentication Required**

## Changes

Inject `Proxy-Authorization: Basic` into the plain HTTP request line before forwarding, mirroring the logic already present in `httpConnect()`.

## Test plan

- [ ] Plain HTTP requests (`http://`) succeed through an authenticated upstream proxy
- [ ] Unauthenticated proxies continue to work (auth header omitted when `upstreamUser` is empty)

Closes https://github.com/nmhjklnm/cac/issues/11