### PR TITLE
fix: use cut -d: -f4- to preserve colons in proxy passwords

### DIFF
--- a/cac
+++ b/cac
@@ -54,7 +54,7 @@ _parse_proxy() {
     host=$(echo "$raw" | cut -d: -f1)
     port=$(echo "$raw" | cut -d: -f2)
     user=$(echo "$raw" | cut -d: -f3)
-    pass=$(echo "$raw" | cut -d: -f4)
+    pass=$(echo "$raw" | cut -d: -f4-)
     if [[ -z "$user" ]]; then
         echo "http://${host}:${port}"
     else
@@ -89,7 +89,7 @@ _auto_detect_proxy() {
     host=$(echo "$raw" | cut -d: -f1)
     port=$(echo "$raw" | cut -d: -f2)
     user=$(echo "$raw" | cut -d: -f3)
-    pass=$(echo "$raw" | cut -d: -f4)
+    pass=$(echo "$raw" | cut -d: -f4-)
     if [[ -n "$user" ]]; then
         auth_part="${user}:${pass}@"
     else

--- a/src/utils.sh
+++ b/src/utils.sh
@@ -45,7 +45,7 @@ _parse_proxy() {
     host=$(echo "$raw" | cut -d: -f1)
     port=$(echo "$raw" | cut -d: -f2)
     user=$(echo "$raw" | cut -d: -f3)
-    pass=$(echo "$raw" | cut -d: -f4)
+    pass=$(echo "$raw" | cut -d: -f4-)
     if [[ -z "$user" ]]; then
         echo "http://${host}:${port}"
     else
@@ -80,7 +80,7 @@ _auto_detect_proxy() {
     host=$(echo "$raw" | cut -d: -f1)
     port=$(echo "$raw" | cut -d: -f2)
     user=$(echo "$raw" | cut -d: -f3)
-    pass=$(echo "$raw" | cut -d: -f4)
+    pass=$(echo "$raw" | cut -d: -f4-)
     if [[ -n "$user" ]]; then
         auth_part="${user}:${pass}@"
     else


### PR DESCRIPTION
## Summary

Both `_parse_proxy()` and `_auto_detect_proxy()` in `src/utils.sh` parse the `host:port:user:pass` format using `cut -d: -f4`, which only captures the **fourth colon-delimited field**. Any colon in the password is treated as a delimiter, silently truncating the password and causing authentication failures.

Example: `proxy.example.com:8080:alice:p@ss:w0rd`
- Before: `pass=p@ss` (`:w0rd` dropped)
- After: `pass=p@ss:w0rd` (correct)

## Changes

Change `cut -d: -f4` → `cut -d: -f4-` in both functions to capture everything from field 4 to end-of-line.

## Test plan

- [ ] `cac add myenv proxy.host:8080:user:p@ss:word` stores and uses the full password
- [ ] Proxy with colon-free password continues to work

Closes https://github.com/nmhjklnm/cac/issues/12