### PR TITLE
fix: add missing stdio, exitCode, signalCode and other properties to makeFakeChildProcess()

### DIFF
--- a/src/fingerprint-hook.js
+++ b/src/fingerprint-hook.js
@@ -98,8 +98,14 @@ function makeFakeChildProcess() {
   cp.stdout = new EventEmitter();
   cp.stderr = new EventEmitter();
   cp.stdin = null;
+  cp.stdio = [null, cp.stdout, cp.stderr];
   cp.pid = 0;
-  cp.kill = () => {};
+  cp.exitCode = null;
+  cp.signalCode = null;
+  cp.killed = false;
+  cp.spawnargs = [];
+  cp.spawnfile = '';
+  cp.kill = () => false;
   return cp;
 }
 


### PR DESCRIPTION
## Summary

`makeFakeChildProcess()` in `src/fingerprint-hook.js` returns a mock `ChildProcess` object used on Windows to intercept `wmic` / `reg` queries. The mock was missing several standard properties defined on real `ChildProcess` instances:

| Property | Expected type | Was |
|----------|--------------|-----|
| `stdio` | `[stdin, stdout, stderr]` array | missing → `undefined` |
| `exitCode` | `number \| null` | missing → `undefined` |
| `signalCode` | `string \| null` | missing → `undefined` |
| `killed` | `boolean` | missing → `undefined` |
| `spawnargs` | `string[]` | missing → `undefined` |
| `spawnfile` | `string` | missing → `undefined` |

Accessing `proc.stdio[0]` throws `TypeError: Cannot read properties of undefined`. Boolean checks on `proc.killed` silently misbehave.

## Changes

Add all missing standard `ChildProcess` properties to the returned mock object.

## Test plan

- [ ] `proc.stdio[0]` returns `null` without throwing
- [ ] `proc.exitCode === null` and `proc.killed === false` on Windows

Closes https://github.com/nmhjklnm/cac/issues/13