### PR TITLE
fix: kill relay and port-forward processes on cac delete

### DIFF
--- a/cac
+++ b/cac
@@ -2618,7 +2618,23 @@ cmd_delete() {
 
     _remove_path_from_rc "$rc_file"
 
+    # 停止 relay 进程和路由
     if [[ -d "$CAC_DIR" ]]; then
+        _relay_stop 2>/dev/null || true
+
+        # 停止 docker port-forward 进程
+        if [[ -d /tmp/cac-docker-ports ]]; then
+            for _pf in /tmp/cac-docker-ports/*.pid; do
+                [[ -f "$_pf" ]] || continue
+                kill "$(cat "$_pf")" 2>/dev/null || true
+                rm -f "$_pf"
+            done
+            echo "  ✓ 已停止 docker port-forward 进程"
+        fi
+
+        # 兜底：清理可能残留的 relay 孤儿进程
+        pkill -f "node.*\.cac/relay\.js" 2>/dev/null || true
+
         rm -rf "$CAC_DIR"
         echo "  ✓ 已删除 $CAC_DIR"
     else

--- a/src/cmd_delete.sh
+++ b/src/cmd_delete.sh
@@ -9,7 +9,23 @@ cmd_delete() {
 
     _remove_path_from_rc "$rc_file"
 
+    # 停止 relay 进程和路由
     if [[ -d "$CAC_DIR" ]]; then
+        _relay_stop 2>/dev/null || true
+
+        # 停止 docker port-forward 进程
+        if [[ -d /tmp/cac-docker-ports ]]; then
+            for _pf in /tmp/cac-docker-ports/*.pid; do
+                [[ -f "$_pf" ]] || continue
+                kill "$(cat "$_pf")" 2>/dev/null || true
+                rm -f "$_pf"
+            done
+            echo "  ✓ 已停止 docker port-forward 进程"
+        fi
+
+        # 兜底：清理可能残留的 relay 孤儿进程
+        pkill -f "node.*\.cac/relay\.js" 2>/dev/null || true
+
         rm -rf "$CAC_DIR"
         echo "  ✓ 已删除 $CAC_DIR"
     else


### PR DESCRIPTION
## Summary

- `cmd_delete()` 在 `rm -rf $CAC_DIR` 前先清理进程：
  - 调用 `_relay_stop` 停止 relay 进程并清理路由
  - 遍历 `/tmp/cac-docker-ports/*.pid` 停止 docker port-forward 进程
  - `pkill -f "node.*\.cac/relay\.js"` 兜底清理孤儿进程
- 重新 build `cac` 产物

## Test plan

- [ ] `cac env create test -p <proxy>` → `cac test` → 启动 relay
- [ ] `cac delete` → 验证 relay 进程被终止（`ps aux | grep relay`）
- [ ] `cac delete` → 验证 `~/.cac/` 目录已删除
- [ ] 无 relay 运行时 `cac delete` 不报错

Closes #21