### PR TITLE
release: v1.5.1

### DIFF
--- a/cac
+++ b/cac
@@ -11,7 +11,7 @@ VERSIONS_DIR="$CAC_DIR/versions"
 # ── utils: colors, read/write, UUID, proxy parsing ───────────────────────
 
 # shellcheck disable=SC2034  # used in build-concatenated cac script
-CAC_VERSION="1.5.1-beta.2"
+CAC_VERSION="1.5.1"
 
 _read()   { [[ -f "$1" ]] && tr -d '[:space:]' < "$1" || echo "${2:-}"; }
 _die()    { printf '%b\n' "$(_red "error:") $*" >&2; exit 1; }

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -5,6 +5,20 @@ description: Release history and notable changes
 
 All notable changes to this project are documented here. Each entry links to the corresponding PR or issue.
 
+## v1.5.1
+<sub>2026-03-31</sub>
+
+**Fix: Relay crash recovery regression** — [Issue #49](https://github.com/nmhjklnm/cac/issues/49)
+
+v1.5.0 removed the relay watchdog along with the EXIT trap, leaving no auto-recovery when the relay process crashes mid-session. Affected users would see **Connection Refused** until manually restarting the session.
+
+- **Env-level watchdog singleton** (`relay.watchdog.pid`): shared across all sessions, auto-restarts relay within 5s of crash. Exits automatically when relay is intentionally stopped — no orphaned processes.
+- **Connectivity check**: watchdog now verifies TCP reachability in addition to process liveness. If the relay port is unresponsive (process alive but frozen), it kills and restarts.
+
+**New: `cac stop` / `cac env stop`**
+
+Pause cac entirely — claude runs natively without any injection (no proxy, no fingerprint spoofing, no CLAUDE_CONFIG_DIR override). Resume with `cac <name>`. Useful when troubleshooting or temporarily bypassing cac.
+
 ## v1.5.0
 <sub>2026-03-29</sub>
 

--- a/docs/zh/changelog.mdx
+++ b/docs/zh/changelog.mdx
@@ -5,6 +5,20 @@ description: 版本发布历史和重要变更
 
 所有重要变更记录在此，每个条目关联对应的 PR 或 Issue。
 
+## v1.5.1
+<sub>2026-03-31</sub>
+
+**修复：Relay 崩溃无法自动恢复（1.5.0 回归）** — [Issue #49](https://github.com/nmhjklnm/cac/issues/49)
+
+1.5.0 在修复多会话共享 relay 时，把 watchdog 和 EXIT trap 一并删掉了。Relay 进程崩溃后无人重启，session 内出现 **Connection Refused**，只能手动重开才能恢复。
+
+- **环境级 watchdog 单例**（`relay.watchdog.pid`）：跨所有 session 共享，relay 崩溃后 5 秒内自动重启。主动停止 relay 时 watchdog 自动退出，不留孤儿进程。
+- **连通性探测**：watchdog 除进程存活检测外，新增 TCP 端口探测。Relay 进程存活但端口无响应时，同样 kill 重启。
+
+**新增：`cac stop` / `cac env stop`**
+
+完全暂停 cac——claude 以原生模式运行，无代理注入、无指纹伪装、无 CLAUDE_CONFIG_DIR 覆盖。用 `cac <name>` 恢复。排查问题或临时绕过 cac 时使用。
+
 ## v1.5.0
 <sub>2026-03-29</sub>
 

--- a/src/utils.sh
+++ b/src/utils.sh
@@ -1,7 +1,7 @@
 # ── utils: colors, read/write, UUID, proxy parsing ───────────────────────
 
 # shellcheck disable=SC2034  # used in build-concatenated cac script
-CAC_VERSION="1.5.1-beta.2"
+CAC_VERSION="1.5.1"
 
 _read()   { [[ -f "$1" ]] && tr -d '[:space:]' < "$1" || echo "${2:-}"; }
 _die()    { printf '%b\n' "$(_red "error:") $*" >&2; exit 1; }


### PR DESCRIPTION
## Summary

- **fix**: relay watchdog restored as env-level singleton with TCP connectivity check — auto-restarts relay within 5s of crash or port freeze (regression from v1.5.0)
- **feat**: `cac stop` / `cac env stop` — pause cac entirely, claude runs natively; `cac <name>` resumes
- **docs**: changelog updated (EN + ZH)

## Changes

- `src/templates.sh` — watchdog TCP reachability check added
- `src/cmd_env.sh` — `_env_cmd_stop` + `cac env stop` dispatch
- `src/main.sh` — `cac stop` shortcut
- `src/utils.sh` — bump to 1.5.1
- `docs/changelog.mdx` + `docs/zh/changelog.mdx` — v1.5.1 entry

Closes #49