### PR TITLE
fix: use --preload= for bun compatibility

### DIFF
--- a/src/templates.sh
+++ b/src/templates.sh
@@ -290,7 +290,7 @@ if [[ -f "$CAC_DIR/cac-dns-guard.js" ]]; then
     esac
     case "${BUN_OPTIONS:-}" in
         *cac-dns-guard.js*) ;;
-        *) export BUN_OPTIONS="${BUN_OPTIONS:-} --preload $CAC_DIR/cac-dns-guard.js" ;;
+        *) export BUN_OPTIONS="${BUN_OPTIONS:-} --preload=$CAC_DIR/cac-dns-guard.js" ;;
     esac
 fi
 # fallback layer: HOSTALIASES (gethostbyname level)
@@ -328,7 +328,7 @@ if [[ -f "$CAC_DIR/fingerprint-hook.js" ]]; then
     esac
     case "${BUN_OPTIONS:-}" in
         *fingerprint-hook.js*) ;;
-        *) export BUN_OPTIONS="--preload $CAC_DIR/fingerprint-hook.js ${BUN_OPTIONS:-}" ;;
+        *) export BUN_OPTIONS="--preload=$CAC_DIR/fingerprint-hook.js ${BUN_OPTIONS:-}" ;;
     esac
 fi
 


### PR DESCRIPTION
## Summary
- Change `--preload <path>` to `--preload=<path>` (equals sign syntax) for both dns-guard and fingerprint-hook BUN_OPTIONS
- Bun requires the `=` form; space-separated form silently fails to load preload scripts

## Test plan
- [ ] Verify dns-guard preload works with `bun` runtime
- [ ] Verify fingerprint-hook preload works with `bun` runtime
- [ ] Confirm no regression with `node` runtime (NODE_OPTIONS unchanged)