### PR TITLE
fix: fingerprint accuracy improvements — 1.5.2-beta.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ node_modules/
 docker/.env
 data/
 CLAUDE.local.md
+
+# internal research docs (not for public)
+docs/internal/

--- a/cac
+++ b/cac
@@ -11,7 +11,7 @@ VERSIONS_DIR="$CAC_DIR/versions"
 # ── utils: colors, read/write, UUID, proxy parsing ───────────────────────
 
 # shellcheck disable=SC2034  # used in build-concatenated cac script
-CAC_VERSION="1.5.1"
+CAC_VERSION="1.5.2-beta.1"
 
 _read()   { [[ -f "$1" ]] && tr -d '[:space:]' < "$1" || echo "${2:-}"; }
 _die()    { printf '%b\n' "$(_red "error:") $*" >&2; exit 1; }
@@ -56,10 +56,23 @@ _gen_uuid() {
     fi
 }
 _new_uuid()    { _gen_uuid | tr '[:lower:]' '[:upper:]'; }
-_new_sid()     { _gen_uuid | tr '[:upper:]' '[:lower:]'; }
 _new_user_id() { python3 -c "import os; print(os.urandom(32).hex())" || _die "python3 required"; }
 _new_machine_id() { _gen_uuid | tr -d '-' | tr '[:upper:]' '[:lower:]'; }
-_new_hostname() { echo "host-$(_gen_uuid | cut -d- -f1 | tr '[:upper:]' '[:lower:]')"; }
+_new_hostname() {
+    local -a _first_names=(
+        "James" "John" "Robert" "Michael" "William" "David" "Richard" "Joseph"
+        "Thomas" "Charles" "Daniel" "Matthew" "Anthony" "Donald" "Mark" "Paul"
+        "Steven" "Andrew" "Kenneth" "Joshua" "Kevin" "Brian" "George" "Timothy"
+        "Emma" "Olivia" "Sophia" "Isabella" "Mia" "Charlotte" "Amelia" "Harper"
+        "Evelyn" "Abigail" "Emily" "Elizabeth" "Sofia" "Avery" "Ella" "Scarlett"
+        "Liam" "Noah" "Oliver" "Elijah" "Lucas" "Mason" "Ethan" "Aiden"
+        "Alex" "Ryan" "Tyler" "Jordan" "Taylor" "Morgan" "Casey" "Riley"
+    )
+    local -a _models=("MacBook-Pro" "MacBook-Air" "MacBook-Pro" "MacBook-Pro")
+    local _name="${_first_names[$((RANDOM % ${#_first_names[@]}))]}"
+    local _model="${_models[$((RANDOM % ${#_models[@]}))]}"
+    echo "${_name}s-${_model}.local"
+}
 _new_mac() { printf '02:%02x:%02x:%02x:%02x:%02x' $((RANDOM%256)) $((RANDOM%256)) $((RANDOM%256)) $((RANDOM%256)) $((RANDOM%256)); }
 _new_git_remote() { echo "https://github.com/user-$(_gen_uuid | cut -d- -f1)/project-$(_gen_uuid | cut -d- -f2).git"; }
 _new_git_email() { echo "user-$(_gen_uuid | cut -d- -f1 | tr '[:upper:]' '[:lower:]')@users.noreply.github.com"; }
@@ -379,20 +392,6 @@ _remove_path_from_rc() {
         rm -f "$tmp"
         echo "  ✓ Removed PATH config from $rc_file (old format)"
         return 0
-    fi
-}
-
-_update_statsig() {
-    local sid="$1"
-    local config_dir="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
-    local statsig="$config_dir/statsig"
-    [[ -d "$statsig" ]] || return 0
-    local found=false
-    for f in "$statsig"/statsig.stable_id.*; do
-        [[ -f "$f" ]] && { printf '"%s"' "$sid" > "$f"; found=true; }
-    done
-    if [[ "$found" == "false" ]]; then
-        printf '"%s"' "$sid" > "$statsig/statsig.stable_id.local"
     fi
 }
 
@@ -1156,19 +1155,6 @@ if [[ -n "$PROXY" ]]; then
     fi
 fi
 
-# inject statsig stable_id
-if [[ -f "$_env_dir/stable_id" ]]; then
-    _sid=$(tr -d '[:space:]' < "$_env_dir/stable_id")
-    _config_dir="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
-    if [[ -d "$_config_dir/statsig" ]]; then
-        _sid_found=false
-        for _f in "$_config_dir/statsig"/statsig.stable_id.*; do
-            [[ -f "$_f" ]] && { printf '"%s"' "$_sid" > "$_f"; _sid_found=true; }
-        done
-        [[ "$_sid_found" == "false" ]] && printf '"%s"' "$_sid" > "$_config_dir/statsig/statsig.stable_id.local"
-    fi
-fi
-
 # inject env vars — proxy (only when proxy is configured)
 if [[ -n "$PROXY" ]]; then
     export _CAC_PROXY="$PROXY"
@@ -1253,6 +1239,13 @@ fi
 # ── persona (Docker/server environment spoofing) ──
 if [[ -f "$_env_dir/persona" ]]; then
     _persona=$(tr -d '[:space:]' < "$_env_dir/persona")
+    # Clear all high-priority detectTerminal() variables before injecting persona,
+    # so real env vars from the host (e.g. CURSOR_TRACE_ID in Cursor) don't override.
+    unset CURSOR_TRACE_ID VSCODE_GIT_ASKPASS_MAIN TERMINAL_EMULATOR VisualStudioVersion
+    unset ITERM_SESSION_ID TERM_PROGRAM __CFBundleIdentifier
+    unset TMUX STY KONSOLE_VERSION GNOME_TERMINAL_SERVICE XTERM_VERSION VTE_VERSION
+    unset TERMINATOR_UUID KITTY_WINDOW_ID ALACRITTY_LOG TILIX_ID WT_SESSION
+    unset MSYSTEM ConEmuANSI ConEmuPID ConEmuTask WSL_DISTRO_NAME
     export TERM="xterm-256color"
     case "$_persona" in
         macos-vscode)
@@ -1318,6 +1311,7 @@ fi
 [[ -f "$_env_dir/mac_address" ]] && export CAC_MAC=$(tr -d '[:space:]' < "$_env_dir/mac_address")
 [[ -f "$_env_dir/machine_id" ]]  && export CAC_MACHINE_ID=$(tr -d '[:space:]' < "$_env_dir/machine_id")
 export CAC_USERNAME="user-$(echo "$_name" | cut -c1-8)"
+export USER="$CAC_USERNAME" LOGNAME="$CAC_USERNAME"
 if [[ -f "$CAC_DIR/fingerprint-hook.js" ]]; then
     case "${NODE_OPTIONS:-}" in
         *fingerprint-hook.js*) ;;
@@ -1736,7 +1730,6 @@ _env_cmd_create() {
     mkdir -p "$env_dir"
     [[ -n "$proxy_url" ]] && echo "$proxy_url" > "$env_dir/proxy"
     echo "$(_new_uuid)"       > "$env_dir/uuid"
-    echo "$(_new_sid)"        > "$env_dir/stable_id"
     echo "$(_new_user_id)"    > "$env_dir/user_id"
     echo "$(_new_machine_id)" > "$env_dir/machine_id"
     echo "$(_new_hostname)"   > "$env_dir/hostname"
@@ -1830,7 +1823,6 @@ MERGE_EOF
     if [[ -d "$env_dir/.claude" ]]; then
         export CLAUDE_CONFIG_DIR="$env_dir/.claude"
     fi
-    _update_statsig "$(_read "$env_dir/stable_id")" 2>/dev/null || true
     _update_claude_json_user_id "$(_read "$env_dir/user_id")" 2>/dev/null || true
 
     local elapsed; elapsed=$(_timer_elapsed)
@@ -1927,7 +1919,6 @@ _env_cmd_activate() {
         export CLAUDE_CONFIG_DIR="$ENVS_DIR/$name/.claude"
     fi
 
-    _update_statsig "$(_read "$ENVS_DIR/$name/stable_id")"
     _update_claude_json_user_id "$(_read "$ENVS_DIR/$name/user_id")"
 
     # Relay lifecycle

--- a/src/cmd_env.sh
+++ b/src/cmd_env.sh
@@ -95,7 +95,6 @@ _env_cmd_create() {
     mkdir -p "$env_dir"
     [[ -n "$proxy_url" ]] && echo "$proxy_url" > "$env_dir/proxy"
     echo "$(_new_uuid)"       > "$env_dir/uuid"
-    echo "$(_new_sid)"        > "$env_dir/stable_id"
     echo "$(_new_user_id)"    > "$env_dir/user_id"
     echo "$(_new_machine_id)" > "$env_dir/machine_id"
     echo "$(_new_hostname)"   > "$env_dir/hostname"
@@ -189,7 +188,6 @@ MERGE_EOF
     if [[ -d "$env_dir/.claude" ]]; then
         export CLAUDE_CONFIG_DIR="$env_dir/.claude"
     fi
-    _update_statsig "$(_read "$env_dir/stable_id")" 2>/dev/null || true
     _update_claude_json_user_id "$(_read "$env_dir/user_id")" 2>/dev/null || true
 
     local elapsed; elapsed=$(_timer_elapsed)
@@ -286,7 +284,6 @@ _env_cmd_activate() {
         export CLAUDE_CONFIG_DIR="$ENVS_DIR/$name/.claude"
     fi
 
-    _update_statsig "$(_read "$ENVS_DIR/$name/stable_id")"
     _update_claude_json_user_id "$(_read "$ENVS_DIR/$name/user_id")"
 
     # Relay lifecycle

--- a/src/fingerprint-hook.js
+++ b/src/fingerprint-hook.js
@@ -99,9 +99,57 @@ if (fakeMachineId) {
 
 // --- Repository fingerprint (rh) interception ---
 // Claude Code computes rh = SHA256(normalized_git_remote_url).hex.slice(0,16)
-// and sends it with every 1p_event — cross-account linkage vector
+// and sends it with every 1p_event — cross-account linkage vector.
+//
+// CC 2.1.88 reads the remote URL via gitFilesystem.ts which calls
+// fs.readFileSync('.git/config') directly — NOT via git subprocess.
+// We intercept both paths for defense in depth.
 const fakeGitRemote = process.env.CAC_FAKE_GIT_REMOTE;
 if (fakeGitRemote) {
+  // Path 1: intercept .git/config reads (primary path in CC 2.1.88)
+  // Replaces the [remote "origin"] url line with our fake remote URL.
+  function isGitConfigPath(p) {
+    var s = typeof p === 'string' ? p : (p && p.toString ? p.toString() : '');
+    return s === '.git/config' || s.endsWith('/.git/config') || s.endsWith('\\.git\\config');
+  }
+  function patchGitConfig(content) {
+    var str = typeof content === 'string' ? content : content.toString('utf8');
+    // Replace url = <anything> under [remote "origin"] section
+    str = str.replace(
+      /(\[remote\s+"origin"\][^\[]*?url\s*=\s*)[^\n]*/,
+      '$1' + fakeGitRemote
+    );
+    return str;
+  }
+
+  // Patch readFileSync (sync path used by gitFilesystem.ts)
+  var _origReadFileSyncRh = fs.readFileSync;
+  fs.readFileSync = function(path, options) {
+    var result = _origReadFileSyncRh.apply(fs, arguments);
+    if (isGitConfigPath(path)) {
+      var patched = patchGitConfig(result);
+      return fakeResult(options, patched);
+    }
+    return result;
+  };
+
+  // Patch fs.promises.readFile (async path)
+  try {
+    var fspRh = require('fs').promises || require('fs/promises');
+    if (fspRh && fspRh.readFile) {
+      var _origPromiseReadFileRh = fspRh.readFile.bind(fspRh);
+      fspRh.readFile = function(path, options) {
+        if (isGitConfigPath(path)) {
+          return _origPromiseReadFileRh(path, options).then(function(content) {
+            return fakeResult(options, patchGitConfig(content));
+          });
+        }
+        return _origPromiseReadFileRh(path, options);
+      };
+    }
+  } catch (_) {}
+
+  // Path 2: intercept git subprocess calls (fallback / older CC versions)
   const GIT_REMOTE_PATTERNS = [
     /git\s+remote\s+get-url/i,
     /git\s+remote\s+-v/i,

--- a/src/templates.sh
+++ b/src/templates.sh
@@ -216,19 +216,6 @@ if [[ -n "$PROXY" ]]; then
     fi
 fi
 
-# inject statsig stable_id
-if [[ -f "$_env_dir/stable_id" ]]; then
-    _sid=$(tr -d '[:space:]' < "$_env_dir/stable_id")
-    _config_dir="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
-    if [[ -d "$_config_dir/statsig" ]]; then
-        _sid_found=false
-        for _f in "$_config_dir/statsig"/statsig.stable_id.*; do
-            [[ -f "$_f" ]] && { printf '"%s"' "$_sid" > "$_f"; _sid_found=true; }
-        done
-        [[ "$_sid_found" == "false" ]] && printf '"%s"' "$_sid" > "$_config_dir/statsig/statsig.stable_id.local"
-    fi
-fi
-
 # inject env vars — proxy (only when proxy is configured)
 if [[ -n "$PROXY" ]]; then
     export _CAC_PROXY="$PROXY"
@@ -313,6 +300,13 @@ fi
 # ── persona (Docker/server environment spoofing) ──
 if [[ -f "$_env_dir/persona" ]]; then
     _persona=$(tr -d '[:space:]' < "$_env_dir/persona")
+    # Clear all high-priority detectTerminal() variables before injecting persona,
+    # so real env vars from the host (e.g. CURSOR_TRACE_ID in Cursor) don't override.
+    unset CURSOR_TRACE_ID VSCODE_GIT_ASKPASS_MAIN TERMINAL_EMULATOR VisualStudioVersion
+    unset ITERM_SESSION_ID TERM_PROGRAM __CFBundleIdentifier
+    unset TMUX STY KONSOLE_VERSION GNOME_TERMINAL_SERVICE XTERM_VERSION VTE_VERSION
+    unset TERMINATOR_UUID KITTY_WINDOW_ID ALACRITTY_LOG TILIX_ID WT_SESSION
+    unset MSYSTEM ConEmuANSI ConEmuPID ConEmuTask WSL_DISTRO_NAME
     export TERM="xterm-256color"
     case "$_persona" in
         macos-vscode)
@@ -378,6 +372,7 @@ fi
 [[ -f "$_env_dir/mac_address" ]] && export CAC_MAC=$(tr -d '[:space:]' < "$_env_dir/mac_address")
 [[ -f "$_env_dir/machine_id" ]]  && export CAC_MACHINE_ID=$(tr -d '[:space:]' < "$_env_dir/machine_id")
 export CAC_USERNAME="user-$(echo "$_name" | cut -c1-8)"
+export USER="$CAC_USERNAME" LOGNAME="$CAC_USERNAME"
 if [[ -f "$CAC_DIR/fingerprint-hook.js" ]]; then
     case "${NODE_OPTIONS:-}" in
         *fingerprint-hook.js*) ;;

--- a/src/utils.sh
+++ b/src/utils.sh
@@ -1,7 +1,7 @@
 # ── utils: colors, read/write, UUID, proxy parsing ───────────────────────
 
 # shellcheck disable=SC2034  # used in build-concatenated cac script
-CAC_VERSION="1.5.1"
+CAC_VERSION="1.5.2-beta.1"
 
 _read()   { [[ -f "$1" ]] && tr -d '[:space:]' < "$1" || echo "${2:-}"; }
 _die()    { printf '%b\n' "$(_red "error:") $*" >&2; exit 1; }
@@ -46,10 +46,23 @@ _gen_uuid() {
     fi
 }
 _new_uuid()    { _gen_uuid | tr '[:lower:]' '[:upper:]'; }
-_new_sid()     { _gen_uuid | tr '[:upper:]' '[:lower:]'; }
 _new_user_id() { python3 -c "import os; print(os.urandom(32).hex())" || _die "python3 required"; }
 _new_machine_id() { _gen_uuid | tr -d '-' | tr '[:upper:]' '[:lower:]'; }
-_new_hostname() { echo "host-$(_gen_uuid | cut -d- -f1 | tr '[:upper:]' '[:lower:]')"; }
+_new_hostname() {
+    local -a _first_names=(
+        "James" "John" "Robert" "Michael" "William" "David" "Richard" "Joseph"
+        "Thomas" "Charles" "Daniel" "Matthew" "Anthony" "Donald" "Mark" "Paul"
+        "Steven" "Andrew" "Kenneth" "Joshua" "Kevin" "Brian" "George" "Timothy"
+        "Emma" "Olivia" "Sophia" "Isabella" "Mia" "Charlotte" "Amelia" "Harper"
+        "Evelyn" "Abigail" "Emily" "Elizabeth" "Sofia" "Avery" "Ella" "Scarlett"
+        "Liam" "Noah" "Oliver" "Elijah" "Lucas" "Mason" "Ethan" "Aiden"
+        "Alex" "Ryan" "Tyler" "Jordan" "Taylor" "Morgan" "Casey" "Riley"
+    )
+    local -a _models=("MacBook-Pro" "MacBook-Air" "MacBook-Pro" "MacBook-Pro")
+    local _name="${_first_names[$((RANDOM % ${#_first_names[@]}))]}"
+    local _model="${_models[$((RANDOM % ${#_models[@]}))]}"
+    echo "${_name}s-${_model}.local"
+}
 _new_mac() { printf '02:%02x:%02x:%02x:%02x:%02x' $((RANDOM%256)) $((RANDOM%256)) $((RANDOM%256)) $((RANDOM%256)) $((RANDOM%256)); }
 _new_git_remote() { echo "https://github.com/user-$(_gen_uuid | cut -d- -f1)/project-$(_gen_uuid | cut -d- -f2).git"; }
 _new_git_email() { echo "user-$(_gen_uuid | cut -d- -f1 | tr '[:upper:]' '[:lower:]')@users.noreply.github.com"; }
@@ -369,20 +382,6 @@ _remove_path_from_rc() {
         rm -f "$tmp"
         echo "  ✓ Removed PATH config from $rc_file (old format)"
         return 0
-    fi
-}
-
-_update_statsig() {
-    local sid="$1"
-    local config_dir="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
-    local statsig="$config_dir/statsig"
-    [[ -d "$statsig" ]] || return 0
-    local found=false
-    for f in "$statsig"/statsig.stable_id.*; do
-        [[ -f "$f" ]] && { printf '"%s"' "$sid" > "$f"; found=true; }
-    done
-    if [[ "$found" == "false" ]]; then
-        printf '"%s"' "$sid" > "$statsig/statsig.stable_id.local"
     fi
 }
 


### PR DESCRIPTION
## Summary

Based on source code analysis of Claude Code 2.1.88 (`instructkr/claude-code`), identified and fixed fingerprint accuracy gaps:

- **hostname**: Replace `host-xxxxx` pattern (100% identifiable by regex) with realistic macOS format (`Daniels-MacBook-Pro.local`) drawn from a name pool
- **persona unset**: Clear all high-priority `detectTerminal()` variables before persona injection — previously, host env vars like `CURSOR_TRACE_ID` could silently override the persona
- **rh interception**: CC 2.1.88 reads `.git/config` directly via `fs.readFileSync`, not via git subprocess — add filesystem-level interception to cover this path
- **Statsig dead code**: CC has fully migrated to GrowthBook; remove `_update_statsig()`, `_new_sid()`, `stable_id` file generation, and wrapper injection block
- **USER/LOGNAME**: `getUsername()` checks `process.env.USER` before `os.userInfo()` — export spoofed username to both so the monkey-patch isn't bypassed

## Test plan

- [x] `cac --version` shows `1.5.2-beta.1`
- [x] New env hostname format: `Joshuas-MacBook-Air.local` (realistic macOS format)
- [x] New env has no `stable_id` file
- [x] Wrapper contains `unset CURSOR_TRACE_ID ...` before persona injection
- [x] Wrapper contains `export USER="$CAC_USERNAME" LOGNAME="$CAC_USERNAME"`
- [x] `fingerprint-hook.js` intercepts `.git/config` reads via `isGitConfigPath`
- [x] `cac env check` on main env: identity 5/5, all good