### PR TITLE
fix: include agents in clone_dirs (v1.5.7)

### DIFF
--- a/cac
+++ b/cac
@@ -11,7 +11,7 @@ VERSIONS_DIR="$CAC_DIR/versions"
 # ── utils: colors, read/write, UUID, proxy parsing ───────────────────────
 
 # shellcheck disable=SC2034  # used in build-concatenated cac script
-CAC_VERSION="1.5.6"
+CAC_VERSION="1.5.7"
 
 _read()   { [[ -f "$1" ]] && tr -d '[:space:]' < "$1" || echo "${2:-}"; }
 _die()    { printf '%b\n' "$(_red "error:") $*" >&2; exit 1; }
@@ -1924,7 +1924,7 @@ _env_cmd_create() {
         fi
 
         if [[ -n "$clone_source" ]] && [[ -d "$src_claude_dir" ]]; then
-            local clone_dirs="commands hooks skills plugins"
+            local clone_dirs="commands agents hooks skills plugins"
             for d in $clone_dirs; do
                 if [[ -d "$src_claude_dir/$d" ]]; then
                     rm -rf "$env_dir/.claude/$d"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-cac",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "description": "Isolate, protect, and manage your Claude Code — versions, environments, identity, and proxy.",
   "bin": {
     "cac": "cac"

--- a/src/cmd_env.sh
+++ b/src/cmd_env.sh
@@ -133,7 +133,7 @@ _env_cmd_create() {
         fi
 
         if [[ -n "$clone_source" ]] && [[ -d "$src_claude_dir" ]]; then
-            local clone_dirs="commands hooks skills plugins"
+            local clone_dirs="commands agents hooks skills plugins"
             for d in $clone_dirs; do
                 if [[ -d "$src_claude_dir/$d" ]]; then
                     rm -rf "$env_dir/.claude/$d"

--- a/src/utils.sh
+++ b/src/utils.sh
@@ -1,7 +1,7 @@
 # ── utils: colors, read/write, UUID, proxy parsing ───────────────────────
 
 # shellcheck disable=SC2034  # used in build-concatenated cac script
-CAC_VERSION="1.5.6"
+CAC_VERSION="1.5.7"
 
 _read()   { [[ -f "$1" ]] && tr -d '[:space:]' < "$1" || echo "${2:-}"; }
 _die()    { printf '%b\n' "$(_red "error:") $*" >&2; exit 1; }


### PR DESCRIPTION
## Summary
- `~/.claude/agents/` was missing from the clone list in `cac env create --clone`, so new envs never got subagent configs.
- Add `agents` alongside `commands/hooks/skills/plugins` in `clone_dirs` (`src/cmd_env.sh:136`).
- Bump `CAC_VERSION` 1.5.6 → 1.5.7.

## Test plan
- [x] `bash build.sh` rebuilds `cac` cleanly.
- [x] `cac env create test --clone host` symlinks `agents` (verified manually before PR).
- [ ] CI: lint + version sync + npm publish on tag.