### PR TITLE
fix(dns-guard): preserve bundled Mozilla roots when injecting mTLS CA

### DIFF
--- a/cac-dns-guard.js
+++ b/cac-dns-guard.js
@@ -187,10 +187,18 @@ if (mtlsCert && mtlsKey) {
         };
 
         // 2b. inject CA into https.globalAgent (trust CA only, no client private key)
+        //
+        // When https.globalAgent.options.ca is undefined (the default), Node
+        // falls back to its bundled Mozilla root certificates. Assigning
+        // [caData] in that case silently REPLACES the bundle, so subsequent
+        // requests to public-cert endpoints (DigiCert, Let's Encrypt, ...)
+        // through https.globalAgent fail with
+        //   "self-signed certificate in certificate chain".
+        // Seed with tls.rootCertificates so the cac CA augments rather than
+        // replaces the default trust store.
         if (caData && https.globalAgent && https.globalAgent.options) {
-            https.globalAgent.options.ca = https.globalAgent.options.ca
-                ? [].concat(https.globalAgent.options.ca, caData)
-                : [caData];
+            var _rootCAs = https.globalAgent.options.ca || tls.rootCertificates;
+            https.globalAgent.options.ca = [].concat(_rootCAs, caData);
         }
     }
 }


### PR DESCRIPTION
## Problem

Any Node.js tool running inside a cac env that uses `https.globalAgent`
(node-fetch@2, axios with the default agent, request, ...) fails on
public-cert HTTPS endpoints with:

> request to https://... failed, reason: self-signed certificate in certificate chain

I hit this with an internal Node CLI reporting to a DigiCert-signed
endpoint — verified with `openssl s_client` that the chain is normal,
so it is not a network-level issue.

## Root cause

`cac-dns-guard.js` section 2b:

```js
https.globalAgent.options.ca = https.globalAgent.options.ca
    ? [].concat(https.globalAgent.options.ca, caData)
    : [caData];
```

When `https.globalAgent.options.ca` is `undefined` (the usual default
— Node falls back to the bundled Mozilla roots only when `ca` is not
set on the agent), this assigns `[caData]`. An agent-level `ca` array
**replaces** the bundled trust store rather than augmenting it, so
only the cac CA is trusted from that point on, and every public chain
ends in an "untrusted self-signed" root.

`NODE_EXTRA_CA_CERTS` does not help, because it adds to the bundled
trust store, not to an agent's explicit `ca` array.

## Trigger conditions

Section 2b runs whenever `CAC_MTLS_CERT && CAC_MTLS_KEY` are present
— there is **no** `CAC_PROXY_HOST` gate (only the `tls.connect`
interception in section 2a is proxy-gated). And `cac env create`
unconditionally generates `client_cert.pem` / `client_key.pem`, while
the `cac claude` wrapper exports `CAC_MTLS_CERT` / `CAC_MTLS_KEY` /
`CAC_MTLS_CA` on every launch when those files exist on disk. So this
fires for essentially every cac env, with or without a proxy
configured.

The bug went largely undetected because Claude Code itself uses native
`fetch` (undici), which has its own connection pool and bypasses
`https.globalAgent`. Tools launched alongside Claude Code that still
rely on node-fetch / axios silently break.

## Repro

In any cac env (before this fix):

```bash
node -e "console.log('ca entries:', require('https').globalAgent.options.ca.length)"
# ca entries: 1     <-- only the cac CA; Mozilla bundle is gone

node -e "require('node-fetch')('https://example.com').then(r=>console.log(r.status)).catch(e=>console.error(e.message))"
# request to https://example.com/ failed,
# reason: self-signed certificate in certificate chain
```

## Fix

Seed `globalAgent.options.ca` with `tls.rootCertificates` (Node's
bundled Mozilla roots) before appending `caData`, so the cac CA is
**added** rather than substituted.

After the patch the same repro prints `ca entries: 151` and the fetch
returns 200.

## Risk / blast radius

- `tls.rootCertificates` is a stable Node API (added in 12.3.0); cac
  already targets modern Node so this is safe.
- Behavior change is strictly additive: mTLS to the cac proxy and any
  custom-CA endpoints still work because `caData` remains in the trust
  list. Endpoints with public certs start working again.
- No other code path needs to change.